### PR TITLE
fix(docs): correct GitHub Pages deploy config for repo move

### DIFF
--- a/jrda-rules-docs/docusaurus.config.ts
+++ b/jrda-rules-docs/docusaurus.config.ts
@@ -13,10 +13,10 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://Paul-Hanlon.github.io',
-  baseUrl: '/jrda-rules/',
-  organizationName: 'Paul-Hanlon',
-  projectName: 'jrda-rules',
+  url: 'https://tbg-development.github.io',
+  baseUrl: '/derby-rules/',
+  organizationName: 'tbg-development',
+  projectName: 'derby-rules',
   trailingSlash: false,
 
   onBrokenLinks: 'throw',


### PR DESCRIPTION
## Summary

The repo moved to `tbg-development/derby-rules`, but `docusaurus.config.ts` still pointed at the old `Paul-Hanlon/jrda-rules` location — so the GitHub Pages docs deploy was misrouted.

Updates four fields:
- `url`: `https://Paul-Hanlon.github.io` → `https://tbg-development.github.io`
- `baseUrl`: `/jrda-rules/` → `/derby-rules/`
- `organizationName`: `Paul-Hanlon` → `tbg-development`
- `projectName`: `jrda-rules` → `derby-rules`

The deploy workflow itself needs no change — it references only the `jrda-rules-docs/` folder name, and `configure-pages`/`deploy-pages` derive org/repo from the GitHub context.

## Scope

Targeted fix only. `title`/`tagline` branding and the `jrda-rules-docs/` folder rename are part of the separate full `derby-rules` migration, not this PR.

## Verification

- `npm run build` in `jrda-rules-docs/` compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)