### PR TITLE
feat: ruleset schema, branding config & model widening (Phase 1)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, inject, provideBrowserGlobalErrorListeners, provideAppInitializer } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { AnalyticsService } from './services/analytics.service';
@@ -9,6 +10,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withComponentInputBinding()),
+    provideHttpClient(withFetch()),
     provideAppInitializer(() => {
       inject(AnalyticsService);
       inject(RemoteConfigService);

--- a/src/app/config/branding.ts
+++ b/src/app/config/branding.ts
@@ -1,0 +1,11 @@
+/**
+ * Central app branding — the single source of truth for the app name,
+ * tagline, and default ruleset. UI strings are wired to read from here in
+ * Phase 5; defined now so later phases have one place to reference.
+ */
+export const BRANDING = {
+  appName: 'Derby Rules',
+  tagline: 'Interactive learning for Roller Derby rules',
+  /** Ruleset selected for new users and when none is stored. */
+  defaultRulesetId: 'jrda',
+} as const;

--- a/src/app/models/reading-age.ts
+++ b/src/app/models/reading-age.ts
@@ -1,1 +1,2 @@
-export type ReadingAge = '7-8' | '9-10' | '11-12' | '13+';
+// Ruleset-defined; historically '7-8' | '9-10' | '11-12' | '13+'.
+export type ReadingAge = string;

--- a/src/app/models/ruleset.ts
+++ b/src/app/models/ruleset.ts
@@ -1,0 +1,116 @@
+/**
+ * Schema for the multi-ruleset content model.
+ *
+ * A ruleset is a self-contained body of Roller Derby rules (WFTDA, JRDA, …).
+ * Rulesets may inherit from a parent via `extends` and supply override files;
+ * the runtime merge engine (Phase 3) resolves a flat tree with per-item
+ * provenance. Nothing consumes these types yet — they are the contract the
+ * loader, merge engine, and ruleset-aware UI are built against.
+ */
+import { ReadingAge } from './reading-age';
+
+/** A reading-age cohort a ruleset ships content for. */
+export interface ReadingAgeDef {
+  id: ReadingAge;
+  label: string;
+}
+
+/** A skill level defined by a ruleset (e.g. JRDA L1/L2/L3). */
+export interface SkillLevelDef {
+  id: string;
+  name: string;
+  description: string;
+  color?: string;
+}
+
+/** Marker shown on rules that are specific to / modified by a ruleset. */
+export interface RulesetBadge {
+  label: string;
+  colorVar?: string;
+}
+
+/** Paths to a ruleset's content files, relative to the ruleset folder. */
+export interface RulesetContentFiles {
+  rules: string;
+  casebook: string;
+  /** reading-age id -> file */
+  glossary: Record<string, string>;
+  /** reading-age id -> file */
+  quizzes: Record<string, string>;
+}
+
+/** Top-level description of a ruleset. */
+export interface RulesetManifest {
+  id: string;
+  /** Short display name, e.g. 'JRDA'. */
+  name: string;
+  /** Full governing-body name, e.g. 'Junior Roller Derby Association'. */
+  fullName: string;
+  description: string;
+  /** false => a structural parent only, never offered to users. */
+  selectable: boolean;
+  /** Parent ruleset id; when set, this ruleset supplies overrides. */
+  extends?: string;
+  /** Reading-age cohorts this ruleset ships content for; [] => no picker. */
+  readingAges: ReadingAgeDef[];
+  /** Skill levels this ruleset defines; [] => no skill-level UI. */
+  skillLevels: SkillLevelDef[];
+  badge?: RulesetBadge;
+  content: RulesetContentFiles;
+}
+
+/* ---- Override operations (keyed by parent item id) ---- */
+
+/** Attach a ruleset-specific note to an inherited rule. */
+export interface AddendumOp {
+  op: 'addendum';
+  id: string;
+  text: string;
+}
+
+/** Replace an inherited item's value, keeping its position. */
+export interface ReplaceOp<T> {
+  op: 'replace';
+  id: string;
+  value: T;
+}
+
+/** Add an item absent from the parent; `after` places it past a sibling id. */
+export interface AddOp<T> {
+  op: 'add';
+  value: T;
+  after?: string;
+}
+
+/** Drop an inherited item. */
+export interface RemoveOp {
+  op: 'remove';
+  id: string;
+}
+
+export type OverrideOp<T> = AddendumOp | ReplaceOp<T> | AddOp<T> | RemoveOp;
+
+/**
+ * One content collection of a ruleset: either a standalone `base` list (no
+ * parent) or an `ops` list applied to the parent's merged collection.
+ */
+export interface CollectionOverride<T> {
+  base?: T[];
+  ops?: OverrideOp<T>[];
+}
+
+/* ---- Merged output ---- */
+
+export type Provenance = 'inherited' | 'added' | 'replaced';
+
+/** Provenance attached to every item after merging. */
+export interface ProvenanceMeta {
+  provenance: Provenance;
+  /** Ruleset that contributed this item. */
+  rulesetId: string;
+  hasAddendum?: boolean;
+  addendumText?: string;
+}
+
+/** An item of type T carrying merge provenance. */
+export type Merged<T> = T & { _meta: ProvenanceMeta };

--- a/src/app/models/skill-level.ts
+++ b/src/app/models/skill-level.ts
@@ -1,4 +1,5 @@
-export type SkillLevel = 'L1' | 'L2' | 'L3';
+// Ruleset-defined; historically the JRDA values 'L1' | 'L2' | 'L3'.
+export type SkillLevel = string;
 
 export interface SkillLevelInfo {
   level: SkillLevel;

--- a/src/app/models/user-profile.ts
+++ b/src/app/models/user-profile.ts
@@ -18,6 +18,7 @@ export interface JuniorProfile {
   dob?: string;
   team?: string;
   level: SkillLevel;
+  rulesetId?: string;
   login?: JuniorLogin;
 }
 
@@ -33,6 +34,7 @@ export interface UserProfile {
   accountType?: AccountType;
   level: SkillLevel;
   readingAge?: ReadingAge;
+  rulesetId?: string;
   skateName?: string;
   number?: string;
   age?: string;


### PR DESCRIPTION
## Summary

**Phase 1** of the multi-ruleset migration (#32) — the type contract and scaffolding the later phases build on. **No behaviour change.**

- **`models/ruleset.ts`** — the multi-ruleset schema: `RulesetManifest`, `ReadingAgeDef`/`SkillLevelDef`, the override-op vocabulary (`addendum`/`replace`/`add`/`remove`), `CollectionOverride`, and the `Provenance`/`Merged<T>` types the loader and merge engine (Phase 3) are built against.
- **`config/branding.ts`** — central `appName` / `tagline` / `defaultRulesetId`.
- Widened `SkillLevel` and `ReadingAge` from literal unions to `string` (ruleset-defined). Grepped first — no exhaustive `switch`es depend on the literals.
- Added optional `rulesetId` to `UserProfile` and `JuniorProfile`.
- Registered `provideHttpClient(withFetch())` ahead of the Phase 3 loader.

## Verification

- `npm run build` ✅
- 9 unit tests pass ✅

Closes #35. Part of #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)