### PR TITLE
feat: merge engine, RulesetService & content loader (Phase 3)

### DIFF
--- a/src/app/models/ruleset.ts
+++ b/src/app/models/ruleset.ts
@@ -8,6 +8,10 @@
  * loader, merge engine, and ruleset-aware UI are built against.
  */
 import { ReadingAge } from './reading-age';
+import { RuleSection } from './rule';
+import { CasebookScenario } from './casebook';
+import { QuizTopic } from './quiz';
+import { GlossaryTerm } from './glossary';
 
 /** A reading-age cohort a ruleset ships content for. */
 export interface ReadingAgeDef {
@@ -114,3 +118,21 @@ export interface ProvenanceMeta {
 
 /** An item of type T carrying merge provenance. */
 export type Merged<T> = T & { _meta: ProvenanceMeta };
+
+/* ---- Loaded ruleset ---- */
+
+/** An entry in the ruleset registry (index.json). */
+export interface RulesetRegistryEntry {
+  id: string;
+  name: string;
+  selectable: boolean;
+}
+
+/** A fully-loaded, merged ruleset — the loader's output. */
+export interface MergedRuleset {
+  manifest: RulesetManifest;
+  rules: Merged<RuleSection>[];
+  casebook: Merged<CasebookScenario>[];
+  glossary: Record<string, Merged<GlossaryTerm>[]>;
+  quizzes: Record<string, Merged<QuizTopic>[]>;
+}

--- a/src/app/services/content-loader.service.spec.ts
+++ b/src/app/services/content-loader.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { MergedRuleset, RulesetRegistryEntry } from '../models/ruleset';
+import { ContentLoaderService } from './content-loader.service';
+import { RulesetLoaderService } from './ruleset-loader.service';
+
+const INDEX: RulesetRegistryEntry[] = [
+  { id: 'wftda', name: 'WFTDA', selectable: false },
+  { id: 'jrda', name: 'JRDA', selectable: true },
+];
+
+const MERGED = {
+  manifest: { id: 'jrda', name: 'JRDA' },
+  rules: [],
+  casebook: [],
+  glossary: {},
+  quizzes: {},
+} as unknown as MergedRuleset;
+
+describe('ContentLoaderService', () => {
+  afterEach(() => localStorage.clear());
+
+  function setup(stub: Partial<RulesetLoaderService>): ContentLoaderService {
+    TestBed.configureTestingModule({
+      providers: [{ provide: RulesetLoaderService, useValue: stub as RulesetLoaderService }],
+    });
+    return TestBed.inject(ContentLoaderService);
+  }
+
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  it('loads to ready and exposes merged content + selectable rulesets', async () => {
+    const svc = setup({
+      loadRulesetContent: () => Promise.resolve(MERGED),
+      loadIndex: () => Promise.resolve(INDEX),
+    });
+    TestBed.tick();
+    await settle();
+
+    expect(svc.state()).toBe('ready');
+    expect(svc.merged()).toBe(MERGED);
+    expect(svc.activeManifest()?.id).toBe('jrda');
+    expect(svc.availableRulesets().map((r) => r.id)).toEqual(['jrda']);
+  });
+
+  it('enters the error state when the loader rejects', async () => {
+    const svc = setup({
+      loadRulesetContent: () => Promise.reject(new Error('boom')),
+      loadIndex: () => Promise.resolve(INDEX),
+    });
+    TestBed.tick();
+    await settle();
+
+    expect(svc.state()).toBe('error');
+    expect(svc.merged()).toBeNull();
+  });
+});

--- a/src/app/services/content-loader.service.ts
+++ b/src/app/services/content-loader.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { MergedRuleset, RulesetManifest, RulesetRegistryEntry } from '../models/ruleset';
+import { RulesetLoaderService } from './ruleset-loader.service';
+import { RulesetService } from './ruleset.service';
+
+export type ContentLoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * The app-level content gate. Loads and merges the active ruleset whenever the
+ * selection changes; the shell waits for `state() === 'ready'` before rendering
+ * so the four data services can expose content synchronously.
+ */
+@Injectable({ providedIn: 'root' })
+export class ContentLoaderService {
+  private readonly loader = inject(RulesetLoaderService);
+  private readonly ruleset = inject(RulesetService);
+
+  private readonly _state = signal<ContentLoadState>('idle');
+  private readonly _merged = signal<MergedRuleset | null>(null);
+  private readonly _available = signal<RulesetRegistryEntry[]>([]);
+
+  /** App-level gate state — the shell waits for 'ready'. */
+  readonly state = this._state.asReadonly();
+  /** Merged content for the active ruleset; null until the first load completes. */
+  readonly merged = this._merged.asReadonly();
+  /** Registry entries the user may choose between. */
+  readonly availableRulesets = computed(() => this._available().filter((r) => r.selectable));
+  /** Manifest of the active ruleset. */
+  readonly activeManifest = computed<RulesetManifest | undefined>(
+    () => this._merged()?.manifest,
+  );
+
+  constructor() {
+    // Reload whenever the effective ruleset changes — including the first run.
+    effect(() => {
+      const id = this.ruleset.rulesetId();
+      void this.load(id);
+    });
+  }
+
+  private async load(id: string): Promise<void> {
+    this._state.set('loading');
+    try {
+      const [merged, index] = await Promise.all([
+        this.loader.loadRulesetContent(id),
+        this.loader.loadIndex(),
+      ]);
+      this._merged.set(merged);
+      this._available.set(index);
+      this._state.set('ready');
+    } catch {
+      this._state.set('error');
+    }
+  }
+}

--- a/src/app/services/ruleset-loader.service.spec.ts
+++ b/src/app/services/ruleset-loader.service.spec.ts
@@ -1,0 +1,120 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { RULE_SECTIONS } from '../data/rules.data';
+import { Rule, RuleSection } from '../models/rule';
+import { RulesetLoaderService } from './ruleset-loader.service';
+
+const ASSETS = join(process.cwd(), 'src/assets/rulesets');
+
+/** The real bundled JSON for a request URL — proves the pipeline end to end. */
+function realFile(url: string): object {
+  const rel = url.replace(/^.*assets\/rulesets\//, '');
+  return JSON.parse(readFileSync(join(ASSETS, rel), 'utf-8')) as object;
+}
+
+/** Recursively drop every `_meta` key so merged output can be compared to TS. */
+function dropMeta(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(dropMeta);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k !== '_meta') out[k] = dropMeta(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** RULE_SECTIONS with jrdaAddendum stripped — the expected WFTDA base shape. */
+function stripAddendum(sections: readonly RuleSection[]): RuleSection[] {
+  const strip = (rule: Rule): Rule => {
+    const out = { ...rule };
+    delete out.jrdaAddendum;
+    if (out.subrules) out.subrules = out.subrules.map(strip);
+    return out;
+  };
+  return sections.map((s) => ({ ...s, rules: s.rules.map(strip) }));
+}
+
+describe('RulesetLoaderService', () => {
+  let loader: RulesetLoaderService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    loader = TestBed.inject(RulesetLoaderService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  /** Resolve a loader promise, flushing each request with its real JSON file. */
+  async function drain<T>(promise: Promise<T>): Promise<T> {
+    let settled = false;
+    promise.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+    for (let i = 0; i < 100 && !settled; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+      for (const req of httpMock.match(() => true)) {
+        req.flush(realFile(req.request.url));
+      }
+    }
+    return promise;
+  }
+
+  it('loads the registry', async () => {
+    const index = await drain(loader.loadIndex());
+    expect(index.map((r) => r.id)).toEqual(['wftda', 'jrda']);
+  });
+
+  it('resolves the jrda extends chain and merges to the original rule structure', async () => {
+    const merged = await drain(loader.loadRulesetContent('jrda'));
+
+    expect(merged.manifest.id).toBe('jrda');
+    // WFTDA base (no jrdaAddendum) re-merged with JRDA addenda == original TS.
+    expect(dropMeta(merged.rules)).toEqual(stripAddendum(RULE_SECTIONS));
+  });
+
+  it('surfaces JRDA addenda as provenance on the merged rules', async () => {
+    const merged = await drain(loader.loadRulesetContent('jrda'));
+
+    const withAddendum: { id: string; text: string }[] = [];
+    const walkMerged = (nodes: unknown): void => {
+      if (!Array.isArray(nodes)) return;
+      for (const node of nodes as Record<string, unknown>[]) {
+        const meta = node['_meta'] as { hasAddendum?: boolean; addendumText?: string } | undefined;
+        if (meta?.hasAddendum) {
+          withAddendum.push({ id: String(node['id']), text: String(meta.addendumText) });
+        }
+        walkMerged(node['rules']);
+        walkMerged(node['subrules']);
+      }
+    };
+    walkMerged(merged.rules);
+
+    const expected: { id: string; text: string }[] = [];
+    const collect = (rules: Rule[]): void => {
+      for (const r of rules) {
+        if (r.jrdaAddendum != null) expected.push({ id: r.id, text: r.jrdaAddendum });
+        if (r.subrules) collect(r.subrules);
+      }
+    };
+    for (const section of RULE_SECTIONS) collect(section.rules);
+
+    expect(withAddendum).toEqual(expected);
+  });
+
+  it('caches content — a second request issues no new HTTP calls', async () => {
+    await drain(loader.loadRulesetContent('jrda'));
+    const again = await loader.loadRulesetContent('jrda');
+    httpMock.expectNone(() => true);
+    expect(again.manifest.id).toBe('jrda');
+  });
+});

--- a/src/app/services/ruleset-loader.service.ts
+++ b/src/app/services/ruleset-loader.service.ts
@@ -1,0 +1,132 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { CasebookScenario } from '../models/casebook';
+import { GlossaryTerm } from '../models/glossary';
+import { QuizTopic } from '../models/quiz';
+import { Rule, RuleSection } from '../models/rule';
+import {
+  CollectionOverride,
+  Merged,
+  MergedRuleset,
+  RulesetManifest,
+  RulesetRegistryEntry,
+} from '../models/ruleset';
+import { mergeCollection, TreeShape } from './ruleset-merge';
+
+/** Rules nest RuleSection -> Rule -> Rule; the engine only needs id + children. */
+type RuleNode = RuleSection | Rule;
+
+const RULES_TREE: TreeShape<RuleNode> = {
+  childrenOf: (n) => ('rules' in n ? n.rules : n.subrules),
+  withChildren: (n, c) =>
+    'rules' in n ? { ...n, rules: c as Rule[] } : { ...n, subrules: c as Rule[] },
+};
+
+/**
+ * Fetches bundled ruleset JSON and resolves the `extends` chain into a single
+ * merged ruleset. Results are cached in memory, so re-selecting a ruleset is
+ * instant. A future Firestore source would slot in behind the same API.
+ */
+@Injectable({ providedIn: 'root' })
+export class RulesetLoaderService {
+  private readonly http = inject(HttpClient);
+  private readonly base = 'assets/rulesets';
+
+  private indexCache?: Promise<RulesetRegistryEntry[]>;
+  private readonly manifestCache = new Map<string, Promise<RulesetManifest>>();
+  private readonly contentCache = new Map<string, Promise<MergedRuleset>>();
+
+  /** The ruleset registry. */
+  loadIndex(): Promise<RulesetRegistryEntry[]> {
+    return (this.indexCache ??= this.getJson<RulesetRegistryEntry[]>('index.json'));
+  }
+
+  loadManifest(id: string): Promise<RulesetManifest> {
+    let cached = this.manifestCache.get(id);
+    if (!cached) {
+      cached = this.getJson<RulesetManifest>(`${id}/manifest.json`);
+      this.manifestCache.set(id, cached);
+    }
+    return cached;
+  }
+
+  /** Resolve a ruleset (and its `extends` ancestors) into one merged ruleset. */
+  loadRulesetContent(id: string): Promise<MergedRuleset> {
+    let cached = this.contentCache.get(id);
+    if (!cached) {
+      cached = this.resolve(id);
+      this.contentCache.set(id, cached);
+    }
+    return cached;
+  }
+
+  private async resolve(id: string): Promise<MergedRuleset> {
+    const chain = await this.resolveChain(id); // root -> ... -> id
+    const leaf = chain[chain.length - 1];
+    const ages = leaf.readingAges.map((a) => a.id);
+
+    let rules: Merged<RuleNode>[] = [];
+    let casebook: Merged<CasebookScenario>[] = [];
+    const glossary: Record<string, Merged<GlossaryTerm>[]> = {};
+    const quizzes: Record<string, Merged<QuizTopic>[]> = {};
+    for (const age of ages) {
+      glossary[age] = [];
+      quizzes[age] = [];
+    }
+
+    for (const manifest of chain) {
+      const files = manifest.content;
+      rules = mergeCollection(
+        rules,
+        await this.getJson<CollectionOverride<RuleNode>>(`${manifest.id}/${files.rules}`),
+        manifest.id,
+        RULES_TREE,
+      );
+      casebook = mergeCollection(
+        casebook,
+        await this.getJson<CollectionOverride<CasebookScenario>>(
+          `${manifest.id}/${files.casebook}`,
+        ),
+        manifest.id,
+      );
+      for (const age of ages) {
+        glossary[age] = mergeCollection(
+          glossary[age],
+          await this.getJson<CollectionOverride<GlossaryTerm>>(
+            `${manifest.id}/${files.glossary[age]}`,
+          ),
+          manifest.id,
+        );
+        quizzes[age] = mergeCollection(
+          quizzes[age],
+          await this.getJson<CollectionOverride<QuizTopic>>(
+            `${manifest.id}/${files.quizzes[age]}`,
+          ),
+          manifest.id,
+        );
+      }
+    }
+
+    return { manifest: leaf, rules: rules as Merged<RuleSection>[], casebook, glossary, quizzes };
+  }
+
+  /** Walk the `extends` chain — returns ancestors first, the requested id last. */
+  private async resolveChain(id: string): Promise<RulesetManifest[]> {
+    const chain: RulesetManifest[] = [];
+    const seen = new Set<string>();
+    let current: string | undefined = id;
+    while (current) {
+      if (seen.has(current)) throw new Error(`Ruleset 'extends' cycle at '${current}'`);
+      seen.add(current);
+      const manifest = await this.loadManifest(current);
+      chain.unshift(manifest);
+      current = manifest.extends;
+    }
+    return chain;
+  }
+
+  private getJson<T>(rel: string): Promise<T> {
+    return firstValueFrom(this.http.get<T>(`${this.base}/${rel}`));
+  }
+}

--- a/src/app/services/ruleset-merge.spec.ts
+++ b/src/app/services/ruleset-merge.spec.ts
@@ -1,0 +1,141 @@
+import { mergeCollection, tagBase, TreeShape } from './ruleset-merge';
+import { Merged } from '../models/ruleset';
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+interface Node {
+  id: string;
+  label: string;
+  kids?: Node[];
+}
+
+const TREE: TreeShape<Node> = {
+  childrenOf: (n) => n.kids,
+  withChildren: (n, c) => ({ ...n, kids: [...c] }),
+};
+
+const m = (n: Node): Merged<Node> => n as Merged<Node>;
+
+describe('ruleset-merge', () => {
+  describe('tagBase', () => {
+    it('tags flat items as inherited', () => {
+      expect(tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda')).toEqual([
+        { id: 'a', label: 'A', _meta: { provenance: 'inherited', rulesetId: 'wftda' } },
+      ]);
+    });
+
+    it('tags nested nodes recursively', () => {
+      const out = tagBase<Node>([{ id: 'p', label: 'P', kids: [{ id: 'c', label: 'C' }] }], 'w', TREE);
+      expect(out[0]._meta).toEqual({ provenance: 'inherited', rulesetId: 'w' });
+      expect(m(out[0].kids![0])._meta).toEqual({ provenance: 'inherited', rulesetId: 'w' });
+    });
+  });
+
+  describe('standalone ruleset', () => {
+    it('mergeCollection with override.base ignores the parent', () => {
+      const out = mergeCollection<Item>([], { base: [{ id: 'a', label: 'A' }] }, 'wftda');
+      expect(out).toEqual([{ id: 'a', label: 'A', _meta: { provenance: 'inherited', rulesetId: 'wftda' } }]);
+    });
+  });
+
+  describe('addendum op', () => {
+    it('sets hasAddendum/addendumText and keeps provenance', () => {
+      const parent = tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda');
+      const out = mergeCollection(parent, { ops: [{ op: 'addendum', id: 'a', text: 'note' }] }, 'jrda');
+      expect(out[0]._meta).toEqual({
+        provenance: 'inherited',
+        rulesetId: 'wftda',
+        hasAddendum: true,
+        addendumText: 'note',
+      });
+    });
+
+    it('targets a nested node by id', () => {
+      const parent = tagBase<Node>([{ id: 'p', label: 'P', kids: [{ id: 'c', label: 'C' }] }], 'w', TREE);
+      const out = mergeCollection(parent, { ops: [{ op: 'addendum', id: 'c', text: 'x' }] }, 'jrda', TREE);
+      expect(m(out[0].kids![0])._meta.hasAddendum).toBe(true);
+      expect(m(out[0].kids![0])._meta.addendumText).toBe('x');
+    });
+  });
+
+  describe('replace op', () => {
+    it('swaps the value and marks it replaced', () => {
+      const parent = tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda');
+      const out = mergeCollection(
+        parent,
+        { ops: [{ op: 'replace', id: 'a', value: { id: 'a', label: 'A2' } }] },
+        'jrda',
+      );
+      expect(out[0].label).toBe('A2');
+      expect(out[0]._meta).toEqual({ provenance: 'replaced', rulesetId: 'jrda' });
+    });
+  });
+
+  describe('add op', () => {
+    it('appends when no `after` is given', () => {
+      const parent = tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda');
+      const out = mergeCollection(parent, { ops: [{ op: 'add', value: { id: 'b', label: 'B' } }] }, 'jrda');
+      expect(out.map((i) => i.id)).toEqual(['a', 'b']);
+      expect(out[1]._meta).toEqual({ provenance: 'added', rulesetId: 'jrda' });
+    });
+
+    it('inserts directly after the `after` sibling, including nested', () => {
+      const parent = tagBase<Node>([{ id: 'p', label: 'P', kids: [{ id: 'c1', label: 'C1' }] }], 'w', TREE);
+      const out = mergeCollection(
+        parent,
+        { ops: [{ op: 'add', after: 'c1', value: { id: 'c2', label: 'C2' } }] },
+        'jrda',
+        TREE,
+      );
+      expect(out[0].kids!.map((k) => k.id)).toEqual(['c1', 'c2']);
+    });
+  });
+
+  describe('remove op', () => {
+    it('drops the item, including from a nested array', () => {
+      const parent = tagBase<Node>(
+        [{ id: 'p', label: 'P', kids: [{ id: 'c1', label: 'C1' }, { id: 'c2', label: 'C2' }] }],
+        'w',
+        TREE,
+      );
+      const out = mergeCollection(parent, { ops: [{ op: 'remove', id: 'c1' }] }, 'jrda', TREE);
+      expect(out[0].kids!.map((k) => k.id)).toEqual(['c2']);
+    });
+  });
+
+  describe('ordering & purity', () => {
+    it('applies ops in order', () => {
+      const parent = tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda');
+      const out = mergeCollection(
+        parent,
+        {
+          ops: [
+            { op: 'add', value: { id: 'b', label: 'B' } },
+            { op: 'remove', id: 'b' },
+          ],
+        },
+        'jrda',
+      );
+      expect(out.map((i) => i.id)).toEqual(['a']);
+    });
+
+    it('does not mutate the parent input', () => {
+      const parent = tagBase<Item>([{ id: 'a', label: 'A' }], 'wftda');
+      const snapshot = structuredClone(parent);
+      mergeCollection(parent, { ops: [{ op: 'addendum', id: 'a', text: 'note' }] }, 'jrda');
+      expect(parent).toEqual(snapshot);
+    });
+
+    it('preserves parent provenance for untouched items across a chain', () => {
+      // wftda base -> jrda adds 'b' -> mrda leaves both untouched
+      const wftda = mergeCollection<Item>([], { base: [{ id: 'a', label: 'A' }] }, 'wftda');
+      const jrda = mergeCollection(wftda, { ops: [{ op: 'add', value: { id: 'b', label: 'B' } }] }, 'jrda');
+      const mrda = mergeCollection(jrda, { ops: [] }, 'mrda');
+      expect(mrda[0]._meta).toEqual({ provenance: 'inherited', rulesetId: 'wftda' });
+      expect(mrda[1]._meta).toEqual({ provenance: 'added', rulesetId: 'jrda' });
+    });
+  });
+});

--- a/src/app/services/ruleset-merge.ts
+++ b/src/app/services/ruleset-merge.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure merge engine for the multi-ruleset content model.
+ *
+ * A ruleset is either standalone (`override.base`) or inherits from a parent
+ * (`override.ops`). `tagBase` seeds the root of an `extends` chain; each child
+ * is then folded on with `mergeCollection`, bottom-up. Every item in the result
+ * carries `_meta` provenance so the UI can mark inherited / added / replaced
+ * items and ruleset-specific addenda.
+ *
+ * The engine is generic over any `{ id: string }` item. Flat collections omit
+ * `tree`; hierarchical ones (rules) pass a `TreeShape` describing how nodes
+ * nest. Ops are matched by `id` at any depth.
+ */
+import { CollectionOverride, Merged, OverrideOp, Provenance } from '../models/ruleset';
+
+/** Describes how a hierarchical collection nests. Omit for flat collections. */
+export interface TreeShape<T> {
+  /** This node's children, or undefined if it has none. */
+  childrenOf(node: T): readonly T[] | undefined;
+  /** A copy of `node` with its children replaced. */
+  withChildren(node: T, children: readonly T[]): T;
+}
+
+/** Recursively attach provenance to a raw node and all its descendants. */
+function tagNode<T extends { id: string }>(
+  node: T,
+  provenance: Provenance,
+  rulesetId: string,
+  tree?: TreeShape<T>,
+): Merged<T> {
+  let base = node;
+  const kids = tree?.childrenOf(node);
+  if (tree && kids) {
+    base = tree.withChildren(
+      node,
+      kids.map((kid) => tagNode(kid, provenance, rulesetId, tree)),
+    );
+  }
+  return { ...base, _meta: { provenance, rulesetId } };
+}
+
+/**
+ * Tag a raw base collection as the root of an `extends` chain — every item
+ * (and descendant) is `inherited` from `rulesetId`.
+ */
+export function tagBase<T extends { id: string }>(
+  base: readonly T[],
+  rulesetId: string,
+  tree?: TreeShape<T>,
+): Merged<T>[] {
+  return base.map((node) => tagNode(node, 'inherited', rulesetId, tree));
+}
+
+/** Locate the array + index holding the item with `id`, searching all depths. */
+function findContainer<T extends { id: string }>(
+  items: Merged<T>[],
+  id: string,
+  tree?: TreeShape<T>,
+): { arr: Merged<T>[]; index: number } | null {
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].id === id) return { arr: items, index: i };
+    const kids = tree?.childrenOf(items[i]) as Merged<T>[] | undefined;
+    if (kids) {
+      const found = findContainer(kids, id, tree);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Apply one override op in place to an already-cloned merged collection. */
+function applyOp<T extends { id: string }>(
+  items: Merged<T>[],
+  op: OverrideOp<T>,
+  rulesetId: string,
+  tree?: TreeShape<T>,
+): void {
+  switch (op.op) {
+    case 'remove': {
+      const found = findContainer(items, op.id, tree);
+      if (found) found.arr.splice(found.index, 1);
+      return;
+    }
+    case 'replace': {
+      const found = findContainer(items, op.id, tree);
+      if (found) found.arr[found.index] = tagNode(op.value, 'replaced', rulesetId, tree);
+      return;
+    }
+    case 'addendum': {
+      const found = findContainer(items, op.id, tree);
+      if (found) {
+        const node = found.arr[found.index];
+        node._meta = { ...node._meta, hasAddendum: true, addendumText: op.text };
+      }
+      return;
+    }
+    case 'add': {
+      const tagged = tagNode(op.value, 'added', rulesetId, tree);
+      if (op.after) {
+        const found = findContainer(items, op.after, tree);
+        if (found) {
+          found.arr.splice(found.index + 1, 0, tagged);
+          return;
+        }
+      }
+      items.push(tagged);
+      return;
+    }
+  }
+}
+
+/**
+ * Merge one ruleset's override onto its parent.
+ *
+ * - Standalone ruleset (`override.base`): `parent` is ignored; the base is
+ *   tagged `inherited`.
+ * - Inheriting ruleset (`override.ops`): the parent's merged result is cloned
+ *   (provenance preserved) and the ops are applied in order.
+ */
+export function mergeCollection<T extends { id: string }>(
+  parent: readonly Merged<T>[],
+  override: CollectionOverride<T>,
+  rulesetId: string,
+  tree?: TreeShape<T>,
+): Merged<T>[] {
+  if (override.base) {
+    return tagBase(override.base, rulesetId, tree);
+  }
+  const items = structuredClone(parent) as Merged<T>[];
+  for (const op of override.ops ?? []) {
+    applyOp(items, op, rulesetId, tree);
+  }
+  return items;
+}

--- a/src/app/services/ruleset.service.spec.ts
+++ b/src/app/services/ruleset.service.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { RulesetService } from './ruleset.service';
+
+describe('RulesetService', () => {
+  afterEach(() => localStorage.clear());
+
+  function make(): RulesetService {
+    return TestBed.inject(RulesetService);
+  }
+
+  it('defaults to jrda when nothing is stored', () => {
+    expect(make().rulesetId()).toBe('jrda');
+  });
+
+  it('setRuleset updates the signal and persists', () => {
+    const svc = make();
+    svc.setRuleset('wftda');
+    expect(svc.selectedRulesetId()).toBe('wftda');
+    expect(localStorage.getItem('derby-rules-ruleset')).toBe('wftda');
+  });
+
+  it('loads a previously stored selection', () => {
+    localStorage.setItem('derby-rules-ruleset', 'mrda');
+    expect(make().selectedRulesetId()).toBe('mrda');
+  });
+
+  it("an active junior's ruleset overrides the account selection", () => {
+    localStorage.setItem('derby-rules-ruleset', 'wftda');
+    localStorage.setItem(
+      'jrda-user-profile',
+      JSON.stringify({
+        role: 'parent',
+        level: 'L1',
+        landed: true,
+        onboarded: true,
+        juniors: [{ skateName: 'Kid', age: '10', level: 'L1', rulesetId: 'jrda' }],
+        activeJuniorIndex: 0,
+      }),
+    );
+    expect(make().rulesetId()).toBe('jrda');
+  });
+});

--- a/src/app/services/ruleset.service.ts
+++ b/src/app/services/ruleset.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { UserProfileService } from './user-profile.service';
+import { BRANDING } from '../config/branding';
+
+const STORAGE_KEY = 'derby-rules-ruleset';
+
+/**
+ * Tracks which ruleset is active. Pure signal + localStorage service, in the
+ * pattern of SkillLevelService — the registry and content come from the loader.
+ *
+ * The storage key is new in this migration, so there is no legacy `jrda-*` key
+ * to migrate (unlike the keys handled in Phase 7).
+ */
+@Injectable({ providedIn: 'root' })
+export class RulesetService {
+  private readonly profile = inject(UserProfileService);
+  private readonly _selected = signal<string>(this.load());
+
+  /** Ruleset the user picked for their own account. */
+  readonly selectedRulesetId = this._selected.asReadonly();
+
+  /**
+   * Effective ruleset. When a parent has stepped into a junior's view, that
+   * junior's own ruleset wins; otherwise the account's selection applies.
+   */
+  readonly rulesetId = computed<string>(
+    () => this.profile.activeJunior()?.rulesetId ?? this._selected(),
+  );
+
+  setRuleset(id: string): void {
+    this._selected.set(id);
+    localStorage.setItem(STORAGE_KEY, id);
+  }
+
+  private load(): string {
+    return localStorage.getItem(STORAGE_KEY) ?? BRANDING.defaultRulesetId;
+  }
+}


### PR DESCRIPTION
## Summary

**Phase 3** of the multi-ruleset migration (#32) — the loader pipeline. Nothing consumes these services yet; the four data services and the app-level gate are wired up in Phase 4, so this PR has **no behaviour change**.

- **`ruleset-merge.ts`** — pure merge engine. Tags a base collection as `inherited`, folds child overrides (`addendum`/`replace`/`add`/`remove`) onto an already-merged parent, recurses hierarchical collections, and carries per-item `_meta` provenance. Generic over any `{ id }` item.
- **`ruleset.service.ts`** — signal service tracking the active ruleset (default `jrda`); an active junior's ruleset overrides the account's selection.
- **`ruleset-loader.service.ts`** — `HttpClient` loader: fetches the registry + manifests, walks the `extends` chain, merges all four content collections, caches the result.
- **`content-loader.service.ts`** — the app-level gate: `state`/`merged` signals, reloads via an `effect` when the ruleset changes.
- **`models/ruleset.ts`** — added `RulesetRegistryEntry` and `MergedRuleset`.

## Verification

37 unit tests pass. The headline check: the **loader spec drives the real bundled JSON through the real loader + merge engine** and asserts the merged JRDA output reproduces the original `RULE_SECTIONS` exactly, with all 8 addenda surfaced as `_meta` provenance.

- `ruleset-merge.spec.ts` — 12 tests: every op, nesting, ordering, purity, multi-level chain.
- `ruleset-loader.service.spec.ts` — extends-chain resolution, merge correctness vs. TS, caching.
- `ruleset.service.spec.ts`, `content-loader.service.spec.ts` — selection + gate state machine.

## Deviation from the plan

`RulesetService` uses the new `derby-rules-ruleset` storage key directly — there's no legacy `jrda-ruleset` key (the ruleset selector is new), so the planned `jrda-ruleset → derby-rules-ruleset` migration is a no-op and was omitted. `availableRulesets`/`activeManifest` live on `ContentLoaderService` (where the loaded registry/manifest data is) rather than `RulesetService`, keeping the latter a pure signal service.

Closes #37. Part of #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)