### PR TITLE
feat: gated ruleset picker in onboarding & profile (Phase 6)

### DIFF
--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -13,6 +13,9 @@ import { SkillLevelService } from '../../services/skill-level.service';
 import { ReadingAgeService } from '../../services/reading-age.service';
 import { AuthService } from '../../services/auth.service';
 import { RemoteConfigService } from '../../services/remote-config.service';
+import { ContentLoaderService } from '../../services/content-loader.service';
+import { RulesetService } from '../../services/ruleset.service';
+import { BRANDING } from '../../config/branding';
 import { DobPickerComponent } from './dob-picker.component';
 import {
   JuniorProfile,
@@ -24,6 +27,7 @@ import { SkillLevel } from '../../models/skill-level';
 
 type Step =
   | 'welcome'
+  | 'rulesetPicker'
   | 'skaterName'
   | 'skaterNumber'
   | 'dob'
@@ -43,6 +47,7 @@ interface SkaterDraft {
   dob: string;
   team: string;
   level: SkillLevel;
+  rulesetId: string;
 }
 
 interface LevelOption {
@@ -115,6 +120,33 @@ interface LevelOption {
                 Already have an account? Sign in
               </button>
             }
+          }
+
+          <!-- SKATER · RULESET -->
+          @case ('rulesetPicker') {
+            <div class="kicker">First up</div>
+            <h1>Which ruleset are you learning?</h1>
+            <p class="subtitle">Pick the rules your league plays by — you can change this later.</p>
+            <div class="choice-list">
+              @for (r of availableRulesets(); track r.id) {
+                <button
+                  type="button"
+                  class="choice-card"
+                  [class.selected]="skater().rulesetId === r.id"
+                  (click)="patchSkater({ rulesetId: r.id })"
+                >
+                  <span class="choice-text">
+                    <span class="choice-title">{{ r.name }}</span>
+                  </span>
+                </button>
+              }
+            </div>
+            <div class="actions end">
+              <button type="button" class="btn btn-primary" (click)="go('skaterName')">
+                Next
+                <app-icon name="chev-right" [size]="18" [strokeWidth]="2.4" />
+              </button>
+            </div>
           }
 
           <!-- SKATER · NAME -->
@@ -409,6 +441,26 @@ interface LevelOption {
                   }
                 </div>
               </div>
+
+              @if (rulesetPickerEnabled()) {
+                <div class="field full">
+                  <span class="label-as-span">Ruleset</span>
+                  <div class="seg-row" role="radiogroup" aria-label="Ruleset">
+                    @for (r of availableRulesets(); track r.id) {
+                      <button
+                        type="button"
+                        role="radio"
+                        class="seg"
+                        [class.on]="parentDraft().rulesetId === r.id"
+                        [attr.aria-checked]="parentDraft().rulesetId === r.id"
+                        (click)="patchParentDraft({ rulesetId: r.id })"
+                      >
+                        {{ r.name }}
+                      </button>
+                    }
+                  </div>
+                </div>
+              }
 
               @if (parentDraftAge() !== null) {
                 <div class="age-pill full">Age: <strong>{{ parentDraftAge() }}</strong></div>
@@ -1158,8 +1210,15 @@ export class OnboardingComponent {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly remoteConfig = inject(RemoteConfigService);
+  private readonly contentLoader = inject(ContentLoaderService);
+  private readonly rulesetService = inject(RulesetService);
   protected readonly authEnabled = this.remoteConfig.flag('auth');
   protected readonly parentOnboardingEnabled = this.remoteConfig.flag('parentOnboarding');
+  protected readonly multiRulesetEnabled = this.remoteConfig.flag('multiRuleset');
+  protected readonly availableRulesets = this.contentLoader.availableRulesets;
+  protected readonly rulesetPickerEnabled = computed(
+    () => this.multiRulesetEnabled() && this.availableRulesets().length > 1,
+  );
 
   protected readonly levels: SkillLevel[] = ['L1', 'L2', 'L3'];
 
@@ -1196,6 +1255,7 @@ export class OnboardingComponent {
     dob: '',
     team: '',
     level: 'L2',
+    rulesetId: BRANDING.defaultRulesetId,
   });
   protected readonly parentDraft = signal<SkaterDraft>({
     skateName: '',
@@ -1203,6 +1263,7 @@ export class OnboardingComponent {
     dob: '',
     team: '',
     level: 'L2',
+    rulesetId: BRANDING.defaultRulesetId,
   });
   protected readonly juniors = signal<JuniorProfile[]>([]);
 
@@ -1229,7 +1290,10 @@ export class OnboardingComponent {
     const m = this.mode();
     const accountStep = this.authEnabled() ? 1 : 0;
     if (m === 'parent') return 4 + accountStep;
-    if (m === 'skater') return (this.skaterIsJunior() ? 6 : 5) + accountStep;
+    if (m === 'skater') {
+      const rulesetStep = this.rulesetPickerEnabled() ? 1 : 0;
+      return (this.skaterIsJunior() ? 6 : 5) + accountStep + rulesetStep;
+    }
     return 1;
   });
 
@@ -1237,8 +1301,10 @@ export class OnboardingComponent {
     const s = this.step();
     const m = this.mode();
     if (s === 'welcome') return 1;
+    if (s === 'rulesetPicker') return 2;
     if (m === 'skater') {
-      if (s === 'account') return this.skaterIsJunior() ? 7 : 6;
+      const off = this.rulesetPickerEnabled() ? 1 : 0;
+      if (s === 'account') return (this.skaterIsJunior() ? 7 : 6) + off;
       const map: Partial<Record<Step, number>> = {
         skaterName: 2,
         skaterNumber: 3,
@@ -1247,7 +1313,7 @@ export class OnboardingComponent {
         team: 5,
         level: 6,
       };
-      return map[s] ?? 1;
+      return (map[s] ?? 1) + off;
     }
     if (m === 'parent') {
       const map: Partial<Record<Step, number>> = {
@@ -1306,7 +1372,7 @@ export class OnboardingComponent {
 
   protected pickSkater(): void {
     this.mode.set('skater');
-    this.go('skaterName');
+    this.go(this.rulesetPickerEnabled() ? 'rulesetPicker' : 'skaterName');
   }
 
   protected pickParent(): void {
@@ -1356,6 +1422,7 @@ export class OnboardingComponent {
       dob: s.dob,
       team: '',
       level: 'L2',
+      rulesetId: s.rulesetId,
     });
     this.stack.set(['welcome', 'parentIntro', 'juniorAdd']);
   }
@@ -1379,6 +1446,7 @@ export class OnboardingComponent {
       dob: s.dob,
       team: s.team.trim() || (isJunior ? 'Unassigned' : ''),
       level,
+      rulesetId: s.rulesetId,
       readingAge: this.readingAgeFromAge(age),
     });
 
@@ -1397,6 +1465,7 @@ export class OnboardingComponent {
       dob: draft.dob,
       team: draft.team.trim() || 'Unassigned',
       level: draft.level,
+      rulesetId: draft.rulesetId,
     };
     this.juniors.update((all) => [...all, jr]);
     this.parentDraft.set({
@@ -1405,6 +1474,7 @@ export class OnboardingComponent {
       dob: '',
       team: '',
       level: 'L2',
+      rulesetId: BRANDING.defaultRulesetId,
     });
     this.go('juniorAddMore');
   }
@@ -1428,6 +1498,7 @@ export class OnboardingComponent {
       dob: active.dob,
       team: active.team,
       level: active.level,
+      rulesetId: active.rulesetId,
       juniors,
       activeJuniorIndex: 0,
       readingAge: this.readingAgeFromAge(age),
@@ -1503,6 +1574,7 @@ export class OnboardingComponent {
     this.profileService.save({ ...profile, landed: true });
     this.skillLevelService.setLevel(profile.level);
     if (profile.readingAge) this.readingAgeService.setReadingAge(profile.readingAge);
+    if (profile.rulesetId) this.rulesetService.setRuleset(profile.rulesetId);
     // Keep derived role consistent for consumers that still read `role`.
     const _derived = roleFromAge(profile.age);
     void _derived;

--- a/src/app/features/profile/profile.component.ts
+++ b/src/app/features/profile/profile.component.ts
@@ -7,6 +7,10 @@ import { ProgressService } from '../../services/progress.service';
 import { JerseyNumberComponent } from '../../shared/components/jersey-number/jersey-number.component';
 import { IconComponent, IconName } from '../../shared/components/icon/icon.component';
 import { TrackOvalComponent } from '../../shared/components/track-oval/track-oval.component';
+import { RemoteConfigService } from '../../services/remote-config.service';
+import { ContentLoaderService } from '../../services/content-loader.service';
+import { RulesetService } from '../../services/ruleset.service';
+import { BRANDING } from '../../config/branding';
 import { ReadingAge } from '../../models/reading-age';
 import { SkillLevel } from '../../models/skill-level';
 
@@ -158,6 +162,32 @@ interface StatTile {
               }
             </label>
           </form>
+
+          @if (rulesetPickerEnabled()) {
+            <div class="junior-block">
+              <div class="junior-group">
+                <div class="group-label">
+                  <span class="group-label-primary">Ruleset</span>
+                  <span class="group-label-sub">which rules you're learning</span>
+                </div>
+                <div class="seg-row" role="radiogroup" aria-label="Ruleset">
+                  @for (r of availableRulesets(); track r.id) {
+                    <button
+                      type="button"
+                      role="radio"
+                      class="seg"
+                      [class.on]="rulesetDraft() === r.id"
+                      [attr.aria-checked]="rulesetDraft() === r.id"
+                      [disabled]="!editing()"
+                      (click)="rulesetDraft.set(r.id)"
+                    >
+                      {{ r.name }}
+                    </button>
+                  }
+                </div>
+              </div>
+            </div>
+          }
 
           @if (isJuniorDraft()) {
             <div class="junior-block">
@@ -627,6 +657,15 @@ export class ProfileComponent {
   private readonly skillLevelService = inject(SkillLevelService);
   private readonly readingAgeService = inject(ReadingAgeService);
   private readonly progressService = inject(ProgressService);
+  private readonly remoteConfig = inject(RemoteConfigService);
+  private readonly contentLoader = inject(ContentLoaderService);
+  private readonly rulesetService = inject(RulesetService);
+
+  protected readonly multiRulesetEnabled = this.remoteConfig.flag('multiRuleset');
+  protected readonly availableRulesets = this.contentLoader.availableRulesets;
+  protected readonly rulesetPickerEnabled = computed(
+    () => this.multiRulesetEnabled() && this.availableRulesets().length > 1,
+  );
 
   protected readonly levelChoices: LevelChoice[] = [
     { value: 'L1', label: 'L1 · New skater' },
@@ -643,6 +682,7 @@ export class ProfileComponent {
   protected readonly teamDraft = signal('');
   protected readonly levelDraft = signal<SkillLevel>('L1');
   protected readonly readingAgeDraft = signal<ReadingAge>('13+');
+  protected readonly rulesetDraft = signal<string>(BRANDING.defaultRulesetId);
 
   protected readonly skateName = computed(() => this.profileService.profile()?.skateName ?? '');
   protected readonly number = computed(() => this.profileService.profile()?.number ?? '00');
@@ -700,6 +740,7 @@ export class ProfileComponent {
     const current = this.profileService.getOrDefault();
     const nextLevel = this.levelDraft();
     const nextReadingAge = this.readingAgeDraft();
+    const pickRuleset = this.rulesetPickerEnabled();
 
     this.profileService.save({
       ...current,
@@ -709,10 +750,12 @@ export class ProfileComponent {
       team: this.teamDraft().trim(),
       level: nextLevel,
       readingAge: nextReadingAge,
+      ...(pickRuleset ? { rulesetId: this.rulesetDraft() } : {}),
     });
 
     this.skillLevelService.setLevel(nextLevel);
     this.readingAgeService.setReadingAge(nextReadingAge);
+    if (pickRuleset) this.rulesetService.setRuleset(this.rulesetDraft());
     this.editing.set(false);
   }
 
@@ -736,5 +779,6 @@ export class ProfileComponent {
     this.teamDraft.set(p.team ?? '');
     this.levelDraft.set(p.level);
     this.readingAgeDraft.set(p.readingAge ?? '13+');
+    this.rulesetDraft.set(this.rulesetService.selectedRulesetId());
   }
 }

--- a/src/app/services/remote-config.service.ts
+++ b/src/app/services/remote-config.service.ts
@@ -18,6 +18,7 @@ const DEFAULTS: Record<string, FlagValue> = {
   badge: false,
   auth: false,
   parentOnboarding: false,
+  multiRuleset: false,
 };
 
 /**


### PR DESCRIPTION
## Summary

**Phase 6** of the multi-ruleset migration (#32) — users can pick their ruleset, behind a flag.

- Added the **`multiRuleset`** Remote Config flag (default **off**).
- **Onboarding**: a ruleset-picker step in the skater flow and a per-junior ruleset field in the parent flow, shown only when `multiRuleset` is on **and** more than one ruleset is selectable. Step counts / progress adjust. The choice is written to the profile and applied via `RulesetService`.
- **Profile**: a gated ruleset selector in the details section, persisted through `RulesetService` on save.

## Verification

With the flag off (default) — and with JRDA the only `selectable` ruleset today — the picker never renders, so onboarding and profile are byte-identical to before. 31 unit tests, build, and **25 e2e tests** pass.

## Note

The skater ruleset step and per-junior field are dormant until a second `selectable` ruleset is authored (`availableRulesets().length > 1`). The skill-level onboarding step stays junior-gated; skill-level *content* is already manifest-conditional from Phase 4 (the data services no-op the filter and the selector reads the manifest).

Closes #40. Part of #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)