### PR TITLE
chore: migrate localStorage keys to derby-rules prefix (Phase 7)

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -9,7 +9,7 @@ describe('App', () => {
     // Seed a landed + onboarded profile so App renders the main shell
     // (header + router outlet) rather than the landing / onboarding gate.
     localStorage.setItem(
-      'jrda-user-profile',
+      'derby-rules-user-profile',
       JSON.stringify({ role: 'skater', level: 'L3', landed: true, onboarded: true }),
     );
     await TestBed.configureTestingModule({

--- a/src/app/services/progress.service.ts
+++ b/src/app/services/progress.service.ts
@@ -1,7 +1,9 @@
 import { computed, Injectable, signal } from '@angular/core';
 import { DEFAULT_PROGRESS, QuizAttempt, UserProgress } from '../models/progress';
+import { migrateStorageKey } from './storage-migration';
 
-const STORAGE_KEY = 'jrda-progress';
+const STORAGE_KEY = 'derby-rules-progress';
+const LEGACY_KEY = 'jrda-progress';
 const CURRENT_VERSION = 1;
 
 @Injectable({ providedIn: 'root' })
@@ -92,6 +94,7 @@ export class ProgressService {
 
   private loadProgress(): UserProgress {
     try {
+      migrateStorageKey(LEGACY_KEY, STORAGE_KEY);
       const stored = localStorage.getItem(STORAGE_KEY);
       if (!stored) return { ...DEFAULT_PROGRESS };
       const parsed = JSON.parse(stored) as UserProgress;

--- a/src/app/services/reading-age.service.ts
+++ b/src/app/services/reading-age.service.ts
@@ -1,8 +1,10 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { ReadingAge } from '../models/reading-age';
 import { UserProfileService } from './user-profile.service';
+import { migrateStorageKey } from './storage-migration';
 
-const STORAGE_KEY = 'jrda-reading-age';
+const STORAGE_KEY = 'derby-rules-reading-age';
+const LEGACY_KEY = 'jrda-reading-age';
 
 @Injectable({ providedIn: 'root' })
 export class ReadingAgeService {
@@ -25,6 +27,7 @@ export class ReadingAgeService {
   }
 
   private loadReadingAge(): ReadingAge {
+    migrateStorageKey(LEGACY_KEY, STORAGE_KEY);
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === '7-8' || stored === '9-10' || stored === '11-12' || stored === '13+') {
       return stored;

--- a/src/app/services/ruleset.service.spec.ts
+++ b/src/app/services/ruleset.service.spec.ts
@@ -27,7 +27,7 @@ describe('RulesetService', () => {
   it("an active junior's ruleset overrides the account selection", () => {
     localStorage.setItem('derby-rules-ruleset', 'wftda');
     localStorage.setItem(
-      'jrda-user-profile',
+      'derby-rules-user-profile',
       JSON.stringify({
         role: 'parent',
         level: 'L1',

--- a/src/app/services/skill-level.service.ts
+++ b/src/app/services/skill-level.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, signal } from '@angular/core';
 import { SkillLevel } from '../models/skill-level';
+import { migrateStorageKey } from './storage-migration';
 
-const STORAGE_KEY = 'jrda-skill-level';
+const STORAGE_KEY = 'derby-rules-skill-level';
+const LEGACY_KEY = 'jrda-skill-level';
 
 @Injectable({ providedIn: 'root' })
 export class SkillLevelService {
@@ -15,6 +17,7 @@ export class SkillLevelService {
   }
 
   private loadLevel(): SkillLevel {
+    migrateStorageKey(LEGACY_KEY, STORAGE_KEY);
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === 'L1' || stored === 'L2' || stored === 'L3') {
       return stored;

--- a/src/app/services/storage-migration.spec.ts
+++ b/src/app/services/storage-migration.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { DEFAULT_PROGRESS } from '../models/progress';
+import { migrateStorageKey } from './storage-migration';
+import { SkillLevelService } from './skill-level.service';
+import { ReadingAgeService } from './reading-age.service';
+import { ProgressService } from './progress.service';
+import { UserProfileService } from './user-profile.service';
+
+describe('migrateStorageKey', () => {
+  afterEach(() => localStorage.clear());
+
+  it('copies a legacy value to the new key and removes the old one', () => {
+    localStorage.setItem('jrda-x', 'value');
+    migrateStorageKey('jrda-x', 'derby-rules-x');
+    expect(localStorage.getItem('derby-rules-x')).toBe('value');
+    expect(localStorage.getItem('jrda-x')).toBeNull();
+  });
+
+  it('leaves an already-migrated new key untouched', () => {
+    localStorage.setItem('jrda-x', 'old');
+    localStorage.setItem('derby-rules-x', 'new');
+    migrateStorageKey('jrda-x', 'derby-rules-x');
+    expect(localStorage.getItem('derby-rules-x')).toBe('new');
+    expect(localStorage.getItem('jrda-x')).toBe('old');
+  });
+
+  it('is a no-op when neither key exists', () => {
+    migrateStorageKey('jrda-x', 'derby-rules-x');
+    expect(localStorage.getItem('derby-rules-x')).toBeNull();
+  });
+});
+
+describe('service storage-key migration', () => {
+  afterEach(() => localStorage.clear());
+
+  it('SkillLevelService migrates jrda-skill-level', () => {
+    localStorage.setItem('jrda-skill-level', 'L2');
+    expect(TestBed.inject(SkillLevelService).level()).toBe('L2');
+    expect(localStorage.getItem('derby-rules-skill-level')).toBe('L2');
+    expect(localStorage.getItem('jrda-skill-level')).toBeNull();
+  });
+
+  it('ReadingAgeService migrates jrda-reading-age', () => {
+    localStorage.setItem('jrda-reading-age', '9-10');
+    expect(TestBed.inject(ReadingAgeService).readingAge()).toBe('9-10');
+    expect(localStorage.getItem('derby-rules-reading-age')).toBe('9-10');
+    expect(localStorage.getItem('jrda-reading-age')).toBeNull();
+  });
+
+  it('ProgressService migrates jrda-progress', () => {
+    localStorage.setItem(
+      'jrda-progress',
+      JSON.stringify({ ...DEFAULT_PROGRESS, readRuleIds: ['1.1'] }),
+    );
+    expect(TestBed.inject(ProgressService).progress().readRuleIds).toEqual(['1.1']);
+    expect(localStorage.getItem('derby-rules-progress')).not.toBeNull();
+    expect(localStorage.getItem('jrda-progress')).toBeNull();
+  });
+
+  it('UserProfileService migrates jrda-user-profile', () => {
+    localStorage.setItem(
+      'jrda-user-profile',
+      JSON.stringify({ role: 'skater', level: 'L3', landed: true, onboarded: true }),
+    );
+    expect(TestBed.inject(UserProfileService).profile()?.role).toBe('skater');
+    expect(localStorage.getItem('derby-rules-user-profile')).not.toBeNull();
+    expect(localStorage.getItem('jrda-user-profile')).toBeNull();
+  });
+});

--- a/src/app/services/storage-migration.ts
+++ b/src/app/services/storage-migration.ts
@@ -1,0 +1,14 @@
+/**
+ * One-time rename of a localStorage key from the legacy `jrda-` prefix to the
+ * current `derby-rules-` prefix. If the new key is absent and the legacy key
+ * exists, the value is copied across and the legacy key removed. Safe to call
+ * on every load — it is a no-op once migrated.
+ */
+export function migrateStorageKey(legacyKey: string, currentKey: string): void {
+  if (localStorage.getItem(currentKey) !== null) return;
+  const legacyValue = localStorage.getItem(legacyKey);
+  if (legacyValue !== null) {
+    localStorage.setItem(currentKey, legacyValue);
+    localStorage.removeItem(legacyKey);
+  }
+}

--- a/src/app/services/user-profile.service.ts
+++ b/src/app/services/user-profile.service.ts
@@ -7,8 +7,10 @@ import {
   UserProfile,
   roleFromAge,
 } from '../models/user-profile';
+import { migrateStorageKey } from './storage-migration';
 
-const STORAGE_KEY = 'jrda-user-profile';
+const STORAGE_KEY = 'derby-rules-user-profile';
+const LEGACY_KEY = 'jrda-user-profile';
 
 const DEFAULT_PROFILE: UserProfile = {
   role: 'skater',
@@ -150,6 +152,7 @@ export class UserProfileService {
 
   private load(): UserProfile | null {
     try {
+      migrateStorageKey(LEGACY_KEY, STORAGE_KEY);
       const stored = localStorage.getItem(STORAGE_KEY);
       if (!stored) return null;
       const parsed = JSON.parse(stored) as UserProfile;


### PR DESCRIPTION
## Summary

**Phase 7** — the final phase of the multi-ruleset migration (#32).

- Added **`migrateStorageKey()`** — a one-time copy-and-delete that renames a legacy `jrda-*` localStorage key to its `derby-rules-*` equivalent (no-op once migrated).
- Renamed the keys for `SkillLevelService`, `ReadingAgeService`, `ProgressService` and `UserProfileService`; each `load()` migrates its legacy key first, so **existing users keep their data** (skill level, reading age, progress, profile).
- `storage-migration.spec.ts` covers the helper and each service: seed the legacy key, construct the service, assert the new key is populated, the old one removed, and the value preserved.

## Verification

38 unit tests (7 new migration tests), production build, and 25 e2e tests pass.

Closes #41. Completes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)